### PR TITLE
Continue processing if one country bounary is broken

### DIFF
--- a/classes/ReverseCountryGeocoder.class.php
+++ b/classes/ReverseCountryGeocoder.class.php
@@ -54,14 +54,19 @@ class ReverseCountryGeocoder
         $features = $geojson["features"];
         $this->mysqli->begin_transaction();
         foreach($features as $feature) {
-            $id = $feature["properties"]["id"];
-            $geom = json_encode($feature["geometry"]);
-            $stmt = $this->mysqli->prepare(
-              'INSERT INTO boundaries (id, shape, area) VALUES (?, ST_GeomFromGeoJSON(?), ST_AREA(ST_GeomFromGeoJSON(?)))'
-            );
-            $stmt->bind_param('sss', $id, $geom, $geom);
-            $stmt->execute();
-            $stmt->close();
+            try {
+                $id = $feature["properties"]["id"];
+                $coords = $feature["geometry"]["coordinates"];
+                $geom = json_encode($feature["geometry"]);
+                $stmt = $this->mysqli->prepare(
+                  'INSERT INTO boundaries (id, shape, area) VALUES (?, ST_GeomFromGeoJSON(?), ST_AREA(ST_GeomFromGeoJSON(?)))'
+                );
+                $stmt->bind_param('sss', $id, $geom, $geom);
+                $stmt->execute();
+                $stmt->close();
+            } catch (Exception $e) {
+                  trigger_error("WARNING: skipping country $id due to error: " . $e->getMessage(), E_USER_WARNING);
+            }
         }
         $this->mysqli->commit();
     }

--- a/classes/ReverseCountryGeocoder.class.php
+++ b/classes/ReverseCountryGeocoder.class.php
@@ -56,7 +56,6 @@ class ReverseCountryGeocoder
         foreach($features as $feature) {
             try {
                 $id = $feature["properties"]["id"];
-                $coords = $feature["geometry"]["coordinates"];
                 $geom = json_encode($feature["geometry"]);
                 $stmt = $this->mysqli->prepare(
                   'INSERT INTO boundaries (id, shape, area) VALUES (?, ST_GeomFromGeoJSON(?), ST_AREA(ST_GeomFromGeoJSON(?)))'


### PR DESCRIPTION
Fixes: https://github.com/streetcomplete/sc-statistics-service/issues/28


With this fix, now it just throws the warning for problematic countries, and continue processing other countries.
So new changesets processed in Portugal and other countries will be correctly detected:
 

> PHP Warning:  WARNING: skipping country RU-CHU due to error: Incorrect GeoJSON format - empty 'coordinates' array. in /home/mnalis/sc-statistics-service/classes/ReverseCountryGeocoder.class.php

(one needs to `drop database boundaries` and scripts will recreate it.)

Old changesets with `null` countries will however remain broken unless refetched/regenerated.

That will be time consuming like the like time I'm afraid... 

But we should regenerate stats for **at least** the user `14617702` who reported the problem and is sad about missing his Portugal stats... (and being number 2 most active SC user globally, IMHO deserves some extra love :heart: )